### PR TITLE
fix: add maxLength validation to user registration

### DIFF
--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -45,9 +45,9 @@ export const usersRoute = new Elysia({ prefix: "/api" })
     },
     {
       body: t.Object({
-        name: t.String(),
-        email: t.String(),
-        password: t.String(),
+        name: t.String({ maxLength: 255 }),
+        email: t.String({ maxLength: 255 }),
+        password: t.String({ maxLength: 255 }),
       }),
     }
   )


### PR DESCRIPTION
Menambahkan validasi \maxLength: 255\ pada skema body registrasi user (\POST /api/users\) untuk mencegah terjadinya 500 Internal Server Error saat input melebihi batas kolom database. Sekarang API akan mengembalikan 422 Unprocessable Entity dengan pesan validasi yang jelas.